### PR TITLE
Use package.json to name the process.

### DIFF
--- a/wotblitz.js
+++ b/wotblitz.js
@@ -4,12 +4,14 @@ var program = require('commander');
 var config = {
   api: require('./config/api.json'),
   app: require('./config/app.json'),
-  version: require('./package.json').version
+  pkg: require('./package.json')
 };
+
+process.title = config.pkg.name;
 
 main(
   program
-    .version('wotblitz.js version ' + config.version)
+    .version('wotblitz.js version ' + config.pkg.version)
     .option('-v, --verbose', 'output more information, like debugging values')
     .parse(process.argv)
 );


### PR DESCRIPTION
Not setting the process name means that 'node'
will appear in `ps` instead of 'wotblitz'.