### PR TITLE
Add servers info endpoint.

### DIFF
--- a/config/api.json
+++ b/config/api.json
@@ -19,5 +19,8 @@
   "tankRecords": {
     "stats": "api.wotblitz.com/wotb/tanks/stats",
     "achievements": "api.wotblitz.com/wotb/tanks/achievements"
+  },
+  "servers": {
+    "info": "api.worldoftanks.com/wgn/servers/info"
   }
 }


### PR DESCRIPTION
This [endpoint](https://na.wargaming.net/developers/api_reference/wgn/servers/info/) provides a player count on wargaming's servers for World of Tanks, World of Tanks Blitz (our interest), and World of Warplanes.