### PR TITLE
Storing the env value is wrong.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,4 @@
 var api = require('../config/api.json');
-var appId = process.env.APPLICATION_ID;
 var https = require('https');
 var querystring = require('querystring');
 var util = require('util');
@@ -9,7 +8,7 @@ module.exports = function requestExports(config) {
 };
 
 function request(config, endpoint, body, callback) {
-  body.application_id = appId;
+  body.application_id = process.env.APPLICATION_ID;
   body = querystring.stringify(body);
 
   var options = {


### PR DESCRIPTION
Getting the `APPLICATION_ID` at require time is wrong because index.js may *set* the value *after* requiring the exports.